### PR TITLE
Handle errors for mobile password reset

### DIFF
--- a/app/(auth)/reset-password/ResetPasswordClient.tsx
+++ b/app/(auth)/reset-password/ResetPasswordClient.tsx
@@ -25,12 +25,13 @@ export default function ResetPasswordClient() {
   // Robust validation: existing session → code param → hash tokens.
   useEffect(() => {
     const validate = async () => {
-      // 1. Session already present?
-      const { data: existing } = await supabase.auth.getSession()
-      if (existing.session) {
-        setStatus("verified")
-        return
-      }
+      try {
+        // 1. Session already present?
+        const { data: existing } = await supabase.auth.getSession()
+        if (existing.session) {
+          setStatus("verified")
+          return
+        }
 
       // 2. PKCE code param?
       const search = new URLSearchParams(window.location.search)
@@ -60,6 +61,11 @@ export default function ResetPasswordClient() {
       // If all strategies fail → error
       setErrorMsg("This reset link is invalid or has expired. Please request a new one.")
       setStatus("error")
+    } catch (err) {
+      console.error("validation error", err)
+      setErrorMsg("Something went wrong validating your reset link.")
+      setStatus("error")
+    }
     }
 
     validate()

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -10,13 +10,13 @@ if (!supabaseUrl || !supabaseAnonKey) {
   )
 }
 
-// Create Supabase client with implicit flow for cross-device compatibility
+// Create Supabase client with PKCE flow for reliable email links on mobile
 export const supabase = createClient(
   supabaseUrl || "",
   supabaseAnonKey || "",
   {
     auth: {
-      flowType: "implicit",
+      flowType: "pkce",
       detectSessionInUrl: true,
       persistSession: true,
       autoRefreshToken: true,


### PR DESCRIPTION
## Summary
- switch Supabase client to PKCE flow so reset links use query params

## Testing
- `pnpm install`
- `npm run lint` *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68737f3b1b00832285b913d46c82708e